### PR TITLE
loading progress bar for gltf model in dreamscene

### DIFF
--- a/components/xr/scene/vrRoom.tsx
+++ b/components/xr/scene/vrRoom.tsx
@@ -4,7 +4,7 @@ import Skybox from './skybox'
 import Lights from './lights'
 import './style.scss'
 import { useDispatch, useSelector } from 'react-redux'
-import { setAppLoaded } from '../../../redux/app/actions'
+import { setAppLoaded, setAppLoadPercent } from '../../../redux/app/actions'
 import { selectAppState } from '../../../redux/app/selector'
 
 export interface VrRoomSceneProps {
@@ -38,6 +38,14 @@ export default function VrRoomScene(props: VrRoomSceneProps) {
           'model-loaded': () => {
             console.log('gltf model loaded.')
             setGltfLoaded(true)
+          },
+          'model-load-progress': (e) => {
+            const progress = e.detail.progress
+            // loaded and total are given as numbers (it seems in bytes), so the percentage loaded can be calculated
+            const { loaded, total } = progress
+            const loadPercent = (loaded / total) * 100
+
+            dispatch(setAppLoadPercent(loadPercent))
           }
         }} />}
       <Lights />

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/socket.io-client": "^1.4.32",
     "@types/three": "^0.103.2",
     "@zeit/next-sass": "^1.0.1",
-    "aframe": "github:xrchat/aframe#xrchat",
+    "aframe": "github:xr3ngine/aframe#xrchat",
     "aframe-animation-component": "^5.1.2",
     "aframe-particle-system-component": "^1.1.3",
     "aframe-react": "^4.4.0",


### PR DESCRIPTION
#327 

Displays a loading bar specifically for the gltf model loaded in /dreamscene

Make sure to install latest modules from the package.json (it uses an updated xr3ngine/aframe).

The loading bar for dreamscene resets after the assets are loaded and then shows the model loading. 
We might want to combine them into a single loading bar, which would mean the gltf model(s) which are to be loaded should have their load progress set in redux, and the loading bar should also take load progress of assets, and then it can take the average or something. That is if the gltf model begins loading immediately along with the assets.